### PR TITLE
Add Next.js frontend with wallet integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 *.log
 .idea/
 *.iml
+**/.next

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,21 @@
+# Frontend
+
+This folder contains a simple Next.js app that interacts with the `NewsPublisher` smart contract.
+
+## Setup
+
+Install dependencies and run the development server:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Set the contract address after deploying the smart contract:
+
+```bash
+export NEXT_PUBLIC_CONTRACT_ADDRESS=0xYourContractAddress
+```
+
+The app allows wallet connection via MetaMask, article publication with IPFS storage, listing of all articles and one-click voting.

--- a/frontend/abi/NewsPublisher.json
+++ b/frontend/abi/NewsPublisher.json
@@ -1,0 +1,51 @@
+[
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "string", "name": "title", "type": "string" },
+      { "internalType": "string", "name": "content", "type": "string" }
+    ],
+    "name": "publishArticle",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "id", "type": "uint256" }],
+    "name": "vote",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAllArticles",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "uint256", "name": "id", "type": "uint256" },
+          { "internalType": "string", "name": "title", "type": "string" },
+          { "internalType": "string", "name": "content", "type": "string" },
+          { "internalType": "address", "name": "author", "type": "address" },
+          { "internalType": "uint256", "name": "voteCount", "type": "uint256" }
+        ],
+        "internalType": "struct NewsPublisher.Article[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/frontend/lib/ipfs.js
+++ b/frontend/lib/ipfs.js
@@ -1,0 +1,8 @@
+import { create } from 'ipfs-http-client';
+
+const client = create({ url: 'https://ipfs.infura.io:5001/api/v0' });
+
+export async function upload(content) {
+  const { path } = await client.add(content);
+  return path;
+}

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^14.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "wagmi": "^1.4.7",
+    "viem": "^1.14.0",
+    "ipfs-http-client": "^63.0.1"
+  }
+}

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -1,0 +1,11 @@
+import { WagmiConfig } from 'wagmi';
+import { config } from '../wagmiConfig';
+import '../styles/globals.css';
+
+export default function App({ Component, pageProps }) {
+  return (
+    <WagmiConfig config={config}>
+      <Component {...pageProps} />
+    </WagmiConfig>
+  );
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,0 +1,133 @@
+import { useState, useEffect } from 'react';
+import { useAccount, useConnect, useDisconnect } from 'wagmi';
+import { MetaMaskConnector } from 'wagmi/connectors/metaMask';
+import { readContract, writeContract } from '@wagmi/core';
+import abi from '../abi/NewsPublisher.json';
+import { upload } from '../lib/ipfs';
+import { config } from '../wagmiConfig';
+
+const contractAddress = process.env.NEXT_PUBLIC_CONTRACT_ADDRESS;
+
+export default function Home() {
+  const { address, isConnected } = useAccount();
+  const { connect } = useConnect({ connector: new MetaMaskConnector() });
+  const { disconnect } = useDisconnect();
+  const [articles, setArticles] = useState([]);
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const fetchArticles = async () => {
+    try {
+      const data = await readContract({
+        address: contractAddress,
+        abi,
+        functionName: 'getAllArticles',
+      });
+      setArticles(data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    if (isConnected) fetchArticles();
+  }, [isConnected]);
+
+  const handlePublish = async () => {
+    setLoading(true);
+    try {
+      const cid = await upload(body);
+      await writeContract({
+        address: contractAddress,
+        abi,
+        functionName: 'publishArticle',
+        args: [title, cid],
+      });
+      setTitle('');
+      setBody('');
+      await fetchArticles();
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleVote = async (id) => {
+    try {
+      await writeContract({
+        address: contractAddress,
+        abi,
+        functionName: 'vote',
+        args: [id],
+      });
+      await fetchArticles();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>News Publisher</h1>
+      {!isConnected ? (
+        <button onClick={() => connect()}>Connect MetaMask</button>
+      ) : (
+        <div>
+          <p>Connected as {address}</p>
+          <button onClick={disconnect}>Disconnect</button>
+        </div>
+      )}
+
+      {isConnected && (
+        <div style={{ marginTop: '2rem' }}>
+          <h2>Publish Article</h2>
+          <input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Title"
+          />
+          <br />
+          <textarea
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            placeholder="Content"
+          />
+          <br />
+          <button onClick={handlePublish} disabled={loading}>
+            Submit
+          </button>
+        </div>
+      )}
+
+      <div style={{ marginTop: '2rem' }}>
+        <h2>Articles</h2>
+        <button onClick={fetchArticles}>Refresh</button>
+        <ul>
+          {articles.map((a) => (
+            <li key={a.id.toString()} style={{ marginBottom: '1rem' }}>
+              <strong>{a.title}</strong> by {a.author} - votes: {a.voteCount}
+              <br />
+              <ArticleContent uri={a.content} />
+              <button onClick={() => handleVote(a.id)}>Vote</button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function ArticleContent({ uri }) {
+  const [content, setContent] = useState('');
+  useEffect(() => {
+    if (!uri) return;
+    fetch(`https://ipfs.io/ipfs/${uri}`)
+      .then((res) => res.text())
+      .then(setContent)
+      .catch((err) => console.error(err));
+  }, [uri]);
+
+  return <p>{content}</p>;
+}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,3 @@
+body {
+  font-family: Arial, sans-serif;
+}

--- a/frontend/wagmiConfig.js
+++ b/frontend/wagmiConfig.js
@@ -1,0 +1,16 @@
+import { configureChains, createConfig } from 'wagmi';
+import { publicProvider } from 'wagmi/providers/public';
+import { MetaMaskConnector } from 'wagmi/connectors/metaMask';
+import { localhost } from 'wagmi/chains';
+
+const { chains, publicClient, webSocketPublicClient } = configureChains(
+  [localhost],
+  [publicProvider()]
+);
+
+export const config = createConfig({
+  autoConnect: true,
+  connectors: [new MetaMaskConnector({ chains })],
+  publicClient,
+  webSocketPublicClient,
+});


### PR DESCRIPTION
## Summary
- scaffold Next.js app under `frontend`
- integrate wagmi for MetaMask connection
- add IPFS upload helper
- implement article publishing, listing and voting via smart contract
- document setup steps

## Testing
- `npm test` *(fails: 403 Forbidden installing hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_688be0ace240832184857350e497c7fd