### PR TITLE
Fix ipfs-http-client dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,6 @@
     "react-dom": "^18.2.0",
     "wagmi": "^1.4.7",
     "viem": "^1.14.0",
-    "ipfs-http-client": "^63.0.1"
+    "ipfs-http-client": "^63.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- fix package.json to reference a valid ipfs-http-client version

## Testing
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_688be81a0ed88321b76ae301077212c9